### PR TITLE
Fix wrong characters in filename if writeLog is enabled

### DIFF
--- a/performance-leaderboard.js
+++ b/performance-leaderboard.js
@@ -67,6 +67,7 @@ async function runLighthouse(urls, numberOfRuns = NUMBER_OF_RUNS, options = {}) 
       }
 
       try {
+        slugify.extend({":": "-", "/": "-"});
         let filename = `lighthouse-${slugify(url)}-${j+1}-of-${numberOfRuns}.json`;
         let rawResult;
         if(opts.readFromLogDirectory) {


### PR DESCRIPTION
When `writeLog` is enabled and URLs have a special character like `:` or `/`, slugify doesn't replace those characters and the log file cannot be created due to the file system file naming restrictions.