### PR TITLE
New axePuppeteerTimeout option, to be able to set puppeteer time…

### DIFF
--- a/performance-leaderboard.js
+++ b/performance-leaderboard.js
@@ -8,6 +8,7 @@ const chromePath = require("puppeteer").executablePath()
 
 const NUMBER_OF_RUNS = 3;
 const LOG_DIRECTORY = ".log";
+const AXE_PUPPETEER_TIMEOUT = 3000
 
 async function runLighthouse(urls, numberOfRuns = NUMBER_OF_RUNS, options = {}) {
   let opts = Object.assign({
@@ -15,6 +16,7 @@ async function runLighthouse(urls, numberOfRuns = NUMBER_OF_RUNS, options = {}) 
     carbonAudit: false,
     logDirectory: LOG_DIRECTORY,
     readFromLogDirectory: false,
+    axePuppeteerTimeout: AXE_PUPPETEER_TIMEOUT,
     // onlyCategories: ["performance", "accessibility"],
     chromeFlags: ['--headless'],
     freshChrome: "site", // or "run"
@@ -33,6 +35,7 @@ async function runLighthouse(urls, numberOfRuns = NUMBER_OF_RUNS, options = {}) 
   resultLog.writeLogs = opts.writeLogs;
   resultLog.readFromLogs = opts.readFromLogDirectory;
   resultLog.carbonAudit = opts.carbonAudit;
+  resultLog.axePuppeteerTimeout = opts.axePuppeteerTimeout;
 
   console.log( `Testing ${urls.length} site${urls.length !== 1 ? "s" : ""}:` );
 

--- a/src/AxeTester.js
+++ b/src/AxeTester.js
@@ -3,7 +3,7 @@ const puppeteer = require("puppeteer");
 const writeLog = require("./WriteLog");
 const readLog = require("./ReadLog");
 const slugify = require("slugify");
- 
+
 class AxeTester {
   set readFromLogs(doRead) {
     this._readFromLogs = doRead;
@@ -21,6 +21,13 @@ class AxeTester {
     return this._writeLogs;
   }
 
+  set puppeteerTimeout(timeout) {
+    this._puppeteerTimeout = timeout;
+  }
+
+  get puppeteerTimeout() {
+    return this._puppeteerTimeout;
+  }
 
   set logDirectory(dir) {
     this._logDir = dir;
@@ -69,7 +76,8 @@ class AxeTester {
     this.page = await this.browser.newPage();
     await this.page.setBypassCSP(true);
     await this.page.goto(url, {
-      waitUntil: ["load", "networkidle0"]
+      waitUntil: ["load", "networkidle0"],
+      timeout: this.puppeteerTimeout
     });
 
     const results = await new AxePuppeteer(this.page).analyze();

--- a/src/ResultLogger.js
+++ b/src/ResultLogger.js
@@ -31,6 +31,14 @@ class ResultLogger {
     return this._logDir;
   }
 
+  set axePuppeteerTimeout(timeout) {
+    this._axePuppeteerTimeout = timeout;
+  }
+
+  get axePuppeteerTimeout() {
+    return this._axePuppeteerTimeout;
+  }
+
   set carbonAudit(isEnabled) {
     this._carbonAudit = isEnabled;
   }
@@ -314,6 +322,7 @@ class ResultLogger {
     axeTester.logDirectory = this.logDirectory;
     axeTester.writeLogs = this.writeLogs;
     axeTester.readFromLogs = this.readFromLogs;
+    axeTester.puppeteerTimeout = this.axePuppeteerTimeout;
 
     // Carbon audit
     if(this.carbonAudit) {


### PR DESCRIPTION
I used this tool to check a big and robust site and axe testing fails because of puppeteer timeout. With this fix, you can specify the timeout in milliseconds for axe testing. 