### PR TITLE
Add carbon estimate results

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/zachleat/performance-leaderboard#readme",
   "dependencies": {
     "@axe-core/puppeteer": "^4.4.3",
+    "@tgwf/co2": "^0.10.4",
     "chrome-launcher": "^0.15.1",
     "lighthouse": "^9.6.3",
     "lodash.get": "^4.4.2",

--- a/performance-leaderboard.js
+++ b/performance-leaderboard.js
@@ -13,6 +13,7 @@ const AXE_PUPPETEER_TIMEOUT = 30000;
 async function runLighthouse(urls, numberOfRuns = NUMBER_OF_RUNS, options = {}) {
   let opts = Object.assign({
     writeLogs: true,
+    carbonAudit: false,
     logDirectory: LOG_DIRECTORY,
     readFromLogDirectory: false,
     axePuppeteerTimeout: AXE_PUPPETEER_TIMEOUT,
@@ -34,6 +35,7 @@ async function runLighthouse(urls, numberOfRuns = NUMBER_OF_RUNS, options = {}) 
   resultLog.logDirectory = opts.logDirectory;
   resultLog.writeLogs = opts.writeLogs;
   resultLog.readFromLogs = opts.readFromLogDirectory;
+  resultLog.carbonAudit = opts.carbonAudit;
   resultLog.axePuppeteerTimeout = opts.axePuppeteerTimeout;
   resultLog.bypassAxe = opts.bypassAxe;
 

--- a/src/CarbonTester.js
+++ b/src/CarbonTester.js
@@ -1,0 +1,85 @@
+const { co2 } = require('@tgwf/co2')
+const writeLog = require("./WriteLog");
+const readLog = require("./ReadLog");
+const slugify = require("slugify");
+
+class CarbonTester {
+  set readFromLogs(doRead) {
+    this._readFromLogs = doRead;
+  }
+
+  get readFromLogs() {
+    return this._readFromLogs;
+  }
+
+  set writeLogs(doWrite) {
+    this._writeLogs = doWrite;
+  }
+
+  get writeLogs() {
+    return this._writeLogs;
+  }
+
+  set logDirectory(dir) {
+    this._logDir = dir;
+  }
+
+  get logDirectory() {
+    return this._logDir;
+  }
+
+  async start() { return; }
+
+  getLogFilename(url) {
+    return `carbon-${slugify(url)}.json`;
+  }
+
+  cleanResults(rawResults) {
+    return rawResults
+  }
+
+  getLogResults(url) {
+    let rawResults = readLog(this.getLogFilename(url), this.logDirectory);
+    if (rawResults === false) {
+      return false;
+    }
+    return rawResults;
+  }
+
+  async calculateNewResult(url, totalWeight) {
+    let results;
+
+    try {
+        const emissions = new co2({ model: "swd" });
+        results = emissions.perByte(totalWeight);
+
+      if(this.writeLogs && results) {
+        await writeLog(this.getLogFilename(url), results, this.logDirectory);
+      }
+    } catch (e) {
+      console.log( `Carbon Audit error with ${url}`, e );
+    }
+
+    return results;
+  }
+
+  async getResults(url, totalWeight) {
+    try {
+      let readResult = this.getLogResults(url);
+      if(this.readFromLogs && readResult !== false) {
+        return readResult;
+      } else {
+        return await this.calculateNewResult(url, totalWeight);
+      }
+    } catch (e) {
+      console.log(`Carbon API error with ${url}`, e);
+
+      return {
+        error: e
+      }
+    }
+  }
+
+  async finish() { return; }
+}
+module.exports = CarbonTester;

--- a/src/ResultLogger.js
+++ b/src/ResultLogger.js
@@ -415,7 +415,7 @@ class ResultLogger {
 
         if (carbonTester){
           console.log(`CO2 scan (${count} of ${size}) for ${url}`);
-          const carbon = await carbonTester.getResults(url, perfResults[0].weight.total);
+          const carbon = await carbonTester.getResults(url, result.weight.total);
           if(carbon) {
             result.carbon = carbon;
           }


### PR DESCRIPTION
This PR adds back carbon estimates which were removed in #16.

The implementation uses [thegreenwebfoundation/co2.js](https://github.com/thegreenwebfoundation/co2.js), so there is no need to make external API calls. The calculations use the median page weight as the basis for calculating a carbon estimate for a page.

Inside CO2.js, we use the Sustainable Web Design (SWD) model however utilise the `perByte` method. This does not apply any of the assumptions caching & return visitor assumptions that are made in the original SWD model. As a result, the carbon estimate returned is higher than what you would see for the same page using a tool like Website Carbon Calculator (which was used previously).

More details on the SWD model, and the CO2.js `perByte` method can be found at the links below:

- [Calculating digital emissions](https://sustainablewebdesign.org/calculating-digital-emissions/) (SWD original post).
- [How the SWD model is applied in CO2.js](https://developers.thegreenwebfoundation.org/co2js/explainer/methodologies-for-calculating-website-carbon/#the-sustainable-web-design-model).
- [Explainer of the `perByte` method](https://developers.thegreenwebfoundation.org/co2js/methods/#perbyte). (Details of the alternate `perVisit` method are also on that page).